### PR TITLE
Scenario documentation api

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -164,10 +164,7 @@ components:
             - finished
             - error
         settings:
-          ## using 'allOf' just to override the description
-          allOf:
-            - $ref: '#/components/schemas/ScenarioSettings'
-          description: execution or default parameters
+          $ref: '#/components/schemas/ScenarioSettings'
     ScenarioExecution:
       required:
         - users

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -29,6 +29,27 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ScenarioList'
+  '/scenarios/{id}/info':
+    get:
+      tags:
+        - scenario
+      description: Get scenario status
+      parameters:
+        - name: id
+          in: path
+          description: Scenario name
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: response object
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScenarioInfo'
+        '404':
+          description: no scenarion with such name
   '/scenarios/{id}':
     get:
       tags:
@@ -151,6 +172,40 @@ components:
           example:
             - some_scenario
             - another_scenario
+    ScenarioInfo:
+      required:
+        - edoc
+      type: object
+      properties:
+        edoc:
+          type: string
+      additionalProperties:
+        type: object
+        required:
+          - module
+          - description
+          - default_value
+          - verification_fn
+          - update_fn
+        properties:
+          module:
+            type: string
+          description:
+            type: string
+          default_value:
+            type: string
+          verification_fn:
+            type: string
+          update_fn:
+            type: string
+      example:
+        edoc: scenario description
+        configuration_parameter:
+          module: module_name
+          description: parameter description
+          default_value: default value
+          verification_fn: MFA or the list of the valid values
+          update_fn: MFA or readonly
     ScenarioStatus:
       required:
         - scenario_status

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -163,6 +163,11 @@ components:
             - running
             - finished
             - error
+        settings:
+          ## using 'allOf' just to override the description
+          allOf:
+            - $ref: '#/components/schemas/ScenarioSettings'
+          description: execution or default parameters
     ScenarioExecution:
       required:
         - users
@@ -173,16 +178,18 @@ components:
           description: Number of users to start
           example: 1000
         settings:
-          type: object
-          description: Scenario parameters
-          additionalProperties:
-            type: string
-          example:
-            atom_parameter: atom1
-            list_parameter: '[atom1, atom2]'
-            tuple_parameter: '{atom1, atom2}'
-            string_parameter: '"some_string"'
-            binary_parameter: <<"some_binary">>
+          $ref: '#/components/schemas/ScenarioSettings'
+    ScenarioSettings:
+      type: object
+      description: Scenario parameters
+      additionalProperties:
+        type: string
+      example:
+        atom_parameter: atom1
+        list_parameter: '[atom1, atom2]'
+        tuple_parameter: '{atom1, atom2}'
+        string_parameter: '"some_string"'
+        binary_parameter: <<"some_binary">>
     ScenarioExecutionResp:
       required:
         - scenario

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -49,7 +49,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ScenarioInfo'
         '404':
-          description: no scenarion with such name
+          description: no scenario with such a name
   '/scenarios/{id}':
     get:
       tags:
@@ -70,7 +70,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ScenarioStatus'
         '404':
-          description: no scenarion with such name
+          description: no scenario with such a name
     patch:
       tags:
         - scenario
@@ -97,7 +97,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ScenarioExecutionResp'
         '404':
-          description: no scenarion with such name
+          description: no scenario with such a name
   /status:
     get:
       tags:
@@ -174,38 +174,46 @@ components:
             - another_scenario
     ScenarioInfo:
       required:
-        - edoc
+        - doc
       type: object
       properties:
-        edoc:
+        doc:
           type: string
-      additionalProperties:
-        type: object
-        required:
-          - module
-          - description
-          - default_value
-          - verification_fn
-          - update_fn
-        properties:
-          module:
-            type: string
-          description:
-            type: string
-          default_value:
-            type: string
-          verification_fn:
-            type: string
-          update_fn:
-            type: string
-      example:
-        edoc: scenario description
-        configuration_parameter:
-          module: module_name
-          description: parameter description
-          default_value: default value
-          verification_fn: MFA or the list of the valid values
-          update_fn: MFA or readonly
+          example: scenario description
+        parameters:
+          type: object
+          additionalProperties:
+            type: object
+            required:
+              - module
+              - description
+              - default_value
+              - verification_fn
+              - update_fn
+            properties:
+              module:
+                type: string
+              description:
+                type: string
+              default_value:
+                type: string
+              verification_fn:
+                type: string
+              update_fn:
+                type: string
+          example:
+            configuration_parameter_name1:
+              module: module_name
+              description: parameter description
+              default_value: default value
+              verification_fn: 'MFA, ''none'' or the list of valid values'
+              update_fn: 'MFA, ''none'' or ''readonly'''
+            configuration_parameter_name2:
+              module: module_name
+              description: parameter description
+              default_value: default value
+              verification_fn: 'MFA, ''none'' or the list of valid values'
+              update_fn: 'MFA, ''none'' or ''readonly'''
     ScenarioStatus:
       required:
         - scenario_status

--- a/priv/openapi.json
+++ b/priv/openapi.json
@@ -70,7 +70,7 @@
             "description" : "response object"
           },
           "404" : {
-            "description" : "no scenarion with such name"
+            "description" : "no scenario with such a name"
           }
         },
         "tags" : [ "scenario" ]
@@ -102,7 +102,7 @@
             "description" : "response object"
           },
           "404" : {
-            "description" : "no scenarion with such name"
+            "description" : "no scenario with such a name"
           }
         },
         "tags" : [ "scenario" ]
@@ -143,7 +143,7 @@
             "description" : "response object"
           },
           "404" : {
-            "description" : "no scenarion with such name"
+            "description" : "no scenario with such a name"
           }
         },
         "tags" : [ "scenario" ]
@@ -253,43 +253,54 @@
         "type" : "object"
       },
       "ScenarioInfo" : {
-        "additionalProperties" : {
-          "properties" : {
-            "module" : {
-              "type" : "string"
-            },
-            "description" : {
-              "type" : "string"
-            },
-            "default_value" : {
-              "type" : "string"
-            },
-            "verification_fn" : {
-              "type" : "string"
-            },
-            "update_fn" : {
-              "type" : "string"
-            }
-          },
-          "required" : [ "default_value", "description", "module", "update_fn", "verification_fn" ],
-          "type" : "object"
-        },
         "example" : {
-          "edoc" : "scenario description",
-          "configuration_parameter" : {
-            "module" : "module_name",
-            "description" : "parameter description",
-            "default_value" : "default value",
-            "verification_fn" : "MFA or the list of the valid values",
-            "update_fn" : "MFA or readonly"
+          "doc" : "scenario description",
+          "parameters" : {
+            "configuration_parameter_name1" : {
+              "module" : "module_name",
+              "description" : "parameter description",
+              "default_value" : "default value",
+              "verification_fn" : "MFA, 'none' or the list of valid values",
+              "update_fn" : "MFA, 'none' or 'readonly'"
+            },
+            "configuration_parameter_name2" : {
+              "module" : "module_name",
+              "description" : "parameter description",
+              "default_value" : "default value",
+              "verification_fn" : "MFA, 'none' or the list of valid values",
+              "update_fn" : "MFA, 'none' or 'readonly'"
+            }
           }
         },
         "properties" : {
-          "edoc" : {
+          "doc" : {
+            "example" : "scenario description",
             "type" : "string"
+          },
+          "parameters" : {
+            "additionalProperties" : {
+              "$ref" : "#/components/schemas/ScenarioInfo_parameters"
+            },
+            "example" : {
+              "configuration_parameter_name1" : {
+                "module" : "module_name",
+                "description" : "parameter description",
+                "default_value" : "default value",
+                "verification_fn" : "MFA, 'none' or the list of valid values",
+                "update_fn" : "MFA, 'none' or 'readonly'"
+              },
+              "configuration_parameter_name2" : {
+                "module" : "module_name",
+                "description" : "parameter description",
+                "default_value" : "default value",
+                "verification_fn" : "MFA, 'none' or the list of valid values",
+                "update_fn" : "MFA, 'none' or 'readonly'"
+              }
+            },
+            "type" : "object"
           }
         },
-        "required" : [ "edoc" ],
+        "required" : [ "doc" ],
         "type" : "object"
       },
       "ScenarioStatus" : {
@@ -428,6 +439,26 @@
         },
         "required" : [ "error" ],
         "type" : "object"
+      },
+      "ScenarioInfo_parameters" : {
+        "properties" : {
+          "module" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "default_value" : {
+            "type" : "string"
+          },
+          "verification_fn" : {
+            "type" : "string"
+          },
+          "update_fn" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "default_value", "description", "module", "update_fn", "verification_fn" ]
       }
     }
   }

--- a/priv/openapi.json
+++ b/priv/openapi.json
@@ -222,7 +222,13 @@
       },
       "ScenarioStatus" : {
         "example" : {
-          "settings" : "",
+          "settings" : {
+            "atom_parameter" : "atom1",
+            "list_parameter" : "[atom1, atom2]",
+            "tuple_parameter" : "{atom1, atom2}",
+            "string_parameter" : "\"some_string\"",
+            "binary_parameter" : "<<\"some_binary\">>"
+          },
           "scenario_status" : "loaded"
         },
         "properties" : {
@@ -231,10 +237,18 @@
             "type" : "string"
           },
           "settings" : {
-            "allOf" : [ {
-              "$ref" : "#/components/schemas/ScenarioSettings"
-            } ],
-            "description" : "execution or default parameters"
+            "additionalProperties" : {
+              "type" : "string"
+            },
+            "description" : "Scenario parameters",
+            "example" : {
+              "atom_parameter" : "atom1",
+              "list_parameter" : "[atom1, atom2]",
+              "tuple_parameter" : "{atom1, atom2}",
+              "string_parameter" : "\"some_string\"",
+              "binary_parameter" : "<<\"some_binary\">>"
+            },
+            "type" : "object"
           }
         },
         "required" : [ "scenario_status" ],

--- a/priv/openapi.json
+++ b/priv/openapi.json
@@ -222,12 +222,19 @@
       },
       "ScenarioStatus" : {
         "example" : {
+          "settings" : "",
           "scenario_status" : "loaded"
         },
         "properties" : {
           "scenario_status" : {
             "enum" : [ "loaded", "running", "finished", "error" ],
             "type" : "string"
+          },
+          "settings" : {
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/ScenarioSettings"
+            } ],
+            "description" : "execution or default parameters"
           }
         },
         "required" : [ "scenario_status" ],
@@ -266,6 +273,20 @@
           }
         },
         "required" : [ "users" ],
+        "type" : "object"
+      },
+      "ScenarioSettings" : {
+        "additionalProperties" : {
+          "type" : "string"
+        },
+        "description" : "Scenario parameters",
+        "example" : {
+          "atom_parameter" : "atom1",
+          "list_parameter" : "[atom1, atom2]",
+          "tuple_parameter" : "{atom1, atom2}",
+          "string_parameter" : "\"some_string\"",
+          "binary_parameter" : "<<\"some_binary\">>"
+        },
         "type" : "object"
       },
       "ScenarioExecutionResp" : {

--- a/priv/openapi.json
+++ b/priv/openapi.json
@@ -44,6 +44,38 @@
         "tags" : [ "scenarios" ]
       }
     },
+    "/scenarios/{id}/info" : {
+      "get" : {
+        "description" : "Get scenario status",
+        "parameters" : [ {
+          "description" : "Scenario name",
+          "explode" : false,
+          "in" : "path",
+          "name" : "id",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "style" : "simple"
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ScenarioInfo"
+                }
+              }
+            },
+            "description" : "response object"
+          },
+          "404" : {
+            "description" : "no scenarion with such name"
+          }
+        },
+        "tags" : [ "scenario" ]
+      }
+    },
     "/scenarios/{id}" : {
       "get" : {
         "description" : "Get scenario status",
@@ -218,6 +250,46 @@
           }
         },
         "required" : [ "scenarios" ],
+        "type" : "object"
+      },
+      "ScenarioInfo" : {
+        "additionalProperties" : {
+          "properties" : {
+            "module" : {
+              "type" : "string"
+            },
+            "description" : {
+              "type" : "string"
+            },
+            "default_value" : {
+              "type" : "string"
+            },
+            "verification_fn" : {
+              "type" : "string"
+            },
+            "update_fn" : {
+              "type" : "string"
+            }
+          },
+          "required" : [ "default_value", "description", "module", "update_fn", "verification_fn" ],
+          "type" : "object"
+        },
+        "example" : {
+          "edoc" : "scenario description",
+          "configuration_parameter" : {
+            "module" : "module_name",
+            "description" : "parameter description",
+            "default_value" : "default value",
+            "verification_fn" : "MFA or the list of the valid values",
+            "update_fn" : "MFA or readonly"
+          }
+        },
+        "properties" : {
+          "edoc" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "edoc" ],
         "type" : "object"
       },
       "ScenarioStatus" : {

--- a/src/amoc_rest_api.erl
+++ b/src/amoc_rest_api.erl
@@ -25,6 +25,11 @@ request_params('ScenariosIdGet') ->
         'id'
     ];
 
+request_params('ScenariosIdInfoGet') ->
+    [
+        'id'
+    ];
+
 request_params('ScenariosIdPatch') ->
     [
         'id',
@@ -78,6 +83,15 @@ request_params(_) ->
 
 
 request_param_info('ScenariosIdGet', 'id') ->
+    #{
+        source =>  binding ,
+        rules => [
+            {type, 'binary'},
+            required
+        ]
+    };
+
+request_param_info('ScenariosIdInfoGet', 'id') ->
     #{
         source =>  binding ,
         rules => [
@@ -158,6 +172,11 @@ validate_response('NodesGet', 200, Body, ValidatorState) ->
 validate_response('ScenariosIdGet', 200, Body, ValidatorState) ->
     validate_response_body('ScenarioStatus', 'ScenarioStatus', Body, ValidatorState);
 validate_response('ScenariosIdGet', 404, Body, ValidatorState) ->
+    validate_response_body('', '', Body, ValidatorState);
+
+validate_response('ScenariosIdInfoGet', 200, Body, ValidatorState) ->
+    validate_response_body('ScenarioInfo', 'ScenarioInfo', Body, ValidatorState);
+validate_response('ScenariosIdInfoGet', 404, Body, ValidatorState) ->
     validate_response_body('', '', Body, ValidatorState);
 
 validate_response('ScenariosIdPatch', 200, Body, ValidatorState) ->

--- a/src/amoc_rest_router.erl
+++ b/src/amoc_rest_router.erl
@@ -65,6 +65,11 @@ get_operations() ->
             method => <<"GET">>,
             handler => 'amoc_rest_scenario_handler'
         },
+        'ScenariosIdInfoGet' => #{
+            path => "/scenarios/:id/info",
+            method => <<"GET">>,
+            handler => 'amoc_rest_scenario_handler'
+        },
         'ScenariosIdPatch' => #{
             path => "/scenarios/:id",
             method => <<"PATCH">>,

--- a/src/amoc_rest_scenario_handler.erl
+++ b/src/amoc_rest_scenario_handler.erl
@@ -57,6 +57,14 @@ allowed_methods(
 allowed_methods(
     Req,
     State = #state{
+        operation_id = 'ScenariosIdInfoGet'
+    }
+) ->
+    {[<<"GET">>], Req, State};
+
+allowed_methods(
+    Req,
+    State = #state{
         operation_id = 'ScenariosIdPatch'
     }
 ) ->
@@ -93,6 +101,16 @@ valid_content_headers(
     Req0,
     State = #state{
         operation_id = 'ScenariosIdGet'
+    }
+) ->
+    Headers = [],
+    {Result, Req} = validate_headers(Headers, Req0),
+    {Result, Req, State};
+
+valid_content_headers(
+    Req0,
+    State = #state{
+        operation_id = 'ScenariosIdInfoGet'
     }
 ) ->
     Headers = [],


### PR DESCRIPTION
this PR adds:
* `/scenarios/{id}/info` REST API
* default/execution scenario `settings` parameter for `/scenarios/{id}` REST API