### PR TITLE
Accept PATCH request without body for '/execution/stop'

### DIFF
--- a/src/amoc_rest_execution_handler.erl
+++ b/src/amoc_rest_execution_handler.erl
@@ -107,6 +107,7 @@ is_authorized(Req, State) ->
 
 content_types_accepted(Req, State) ->
     {[
+        {undefined, handle_request_json},
         {<<"application/json">>, handle_request_json}
     ], Req, State}.
 


### PR DESCRIPTION
This fix is needed to make cowboy accept the PATCH request without body for stopping the scenario.