### PR TITLE
reworking status api

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -94,7 +94,7 @@ paths:
           description: Scenario name
           required: true
           schema:
-            type: string
+            $ref: '#/components/schemas/Node'
       responses:
         '200':
           description: response object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -33,7 +33,7 @@ paths:
     get:
       tags:
         - scenarios
-      description: Get scenario status
+      description: Get scenario description
       parameters:
         - name: id
           in: path
@@ -54,7 +54,7 @@ paths:
     get:
       tags:
         - scenarios
-      description: Get scenario status
+      description: Get scenario default settings
       parameters:
         - name: id
           in: path
@@ -87,11 +87,11 @@ paths:
     get:
       tags:
         - status
-      description: Get AMOC app status
+      description: Get AMOC app status on a remote node
       parameters:
         - name: node
           in: path
-          description: Scenario name
+          description: Node name
           required: true
           schema:
             $ref: '#/components/schemas/Node'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -29,7 +29,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ScenarioList'
-  '/scenarios/{id}/info':
+  '/scenarios/info/{id}':
     get:
       tags:
         - scenarios
@@ -50,7 +50,7 @@ paths:
                 $ref: '#/components/schemas/ScenarioInfo'
         '404':
           description: no scenario with such a name
-  '/scenarios/{id}':
+  '/scenarios/defaults/{id}':
     get:
       tags:
         - scenarios
@@ -68,14 +68,14 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ScenarioStatus'
+                $ref: '#/components/schemas/ScenarioDefaults'
         '404':
           description: no scenario with such a name
   /status:
     get:
       tags:
         - status
-      description: 'Get AMOC app status, whether it is running or not.'
+      description: Get AMOC app status
       responses:
         '200':
           description: response object
@@ -83,6 +83,27 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AmocStatus'
+  '/status/{node}':
+    get:
+      tags:
+        - status
+      description: Get AMOC app status
+      parameters:
+        - name: node
+          in: path
+          description: Scenario name
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: response object
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AmocStatus'
+        '404':
+          description: no node with such a name
   /scenarios/upload:
     put:
       tags:
@@ -297,18 +318,11 @@ components:
               default_value: default value
               verification_fn: 'MFA, ''none'' or the list of valid values'
               update_fn: 'MFA, ''none'' or ''readonly'''
-    ScenarioStatus:
+    ScenarioDefaults:
       required:
-        - scenario_status
+        - settings
       type: object
       properties:
-        scenario_status:
-          type: string
-          enum:
-            - loaded
-            - running
-            - finished
-            - error
         settings:
           $ref: '#/components/schemas/ScenarioSettings'
     ScenarioSettings:
@@ -324,14 +338,71 @@ components:
         binary_parameter: <<"some_binary">>
     AmocStatus:
       required:
-        - node_status
+        - amoc_status
+        - env
       type: object
+      description: |
+        "controller" field is mandatory if "amoc_status" is "up".
       properties:
-        node_status:
+        amoc_status:
           type: string
           enum:
             - up
             - down
+        env:
+          type: object
+          description: environment variables
+          additionalProperties:
+            type: string
+          example:
+            AMOC_INTERARRIVAL: '50'
+        controller:
+          $ref: '#/components/schemas/ControllerStatus'
+    ControllerStatus:
+      type: object
+      description: >
+        controller is "disabled" on the master node.
+
+
+        "scenario" and "settings" fields are included if "status" is "running",
+        "terminating" or "finished"
+
+
+        "number_of_users" field is relevant only when controller is in "running"
+        state.
+
+
+        "error" field is relevant only when controller is in "error" state.
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          enum:
+            - idle
+            - running
+            - terminating
+            - finished
+            - error
+            - disabled
+        scenario:
+          type: string
+        number_of_users:
+          type: integer
+        settings:
+          $ref: '#/components/schemas/ScenarioSettings'
+        error:
+          type: string
+      example:
+        status: running
+        scenario: some_scenario
+        number_of_users: 10
+        settings:
+          atom_parameter: atom1
+          list_parameter: '[atom1, atom2]'
+          tuple_parameter: '{atom1, atom2}'
+          string_parameter: '"some_string"'
+          binary_parameter: <<"some_binary">>
     UploadBody:
       type: string
       format: binary

--- a/priv/openapi.json
+++ b/priv/openapi.json
@@ -44,7 +44,7 @@
         "tags" : [ "scenarios" ]
       }
     },
-    "/scenarios/{id}/info" : {
+    "/scenarios/info/{id}" : {
       "get" : {
         "description" : "Get scenario status",
         "parameters" : [ {
@@ -76,7 +76,7 @@
         "tags" : [ "scenarios" ]
       }
     },
-    "/scenarios/{id}" : {
+    "/scenarios/defaults/{id}" : {
       "get" : {
         "description" : "Get scenario status",
         "parameters" : [ {
@@ -95,7 +95,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/ScenarioStatus"
+                  "$ref" : "#/components/schemas/ScenarioDefaults"
                 }
               }
             },
@@ -110,7 +110,7 @@
     },
     "/status" : {
       "get" : {
-        "description" : "Get AMOC app status, whether it is running or not.",
+        "description" : "Get AMOC app status",
         "responses" : {
           "200" : {
             "content" : {
@@ -121,6 +121,38 @@
               }
             },
             "description" : "response object"
+          }
+        },
+        "tags" : [ "status" ]
+      }
+    },
+    "/status/{node}" : {
+      "get" : {
+        "description" : "Get AMOC app status",
+        "parameters" : [ {
+          "description" : "Scenario name",
+          "explode" : false,
+          "in" : "path",
+          "name" : "node",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "style" : "simple"
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AmocStatus"
+                }
+              }
+            },
+            "description" : "response object"
+          },
+          "404" : {
+            "description" : "no node with such a name"
           }
         },
         "tags" : [ "status" ]
@@ -426,7 +458,7 @@
         "required" : [ "doc" ],
         "type" : "object"
       },
-      "ScenarioStatus" : {
+      "ScenarioDefaults" : {
         "example" : {
           "settings" : {
             "atom_parameter" : "atom1",
@@ -434,14 +466,9 @@
             "tuple_parameter" : "{atom1, atom2}",
             "string_parameter" : "\"some_string\"",
             "binary_parameter" : "<<\"some_binary\">>"
-          },
-          "scenario_status" : "loaded"
+          }
         },
         "properties" : {
-          "scenario_status" : {
-            "enum" : [ "loaded", "running", "finished", "error" ],
-            "type" : "string"
-          },
           "settings" : {
             "additionalProperties" : {
               "type" : "string"
@@ -457,7 +484,7 @@
             "type" : "object"
           }
         },
-        "required" : [ "scenario_status" ],
+        "required" : [ "settings" ],
         "type" : "object"
       },
       "ScenarioSettings" : {
@@ -475,16 +502,91 @@
         "type" : "object"
       },
       "AmocStatus" : {
+        "description" : "\"controller\" field is mandatory if \"amoc_status\" is \"up\".\n",
         "example" : {
-          "node_status" : "up"
+          "controller" : {
+            "status" : "running",
+            "scenario" : "some_scenario",
+            "number_of_users" : 10,
+            "settings" : {
+              "atom_parameter" : "atom1",
+              "list_parameter" : "[atom1, atom2]",
+              "tuple_parameter" : "{atom1, atom2}",
+              "string_parameter" : "\"some_string\"",
+              "binary_parameter" : "<<\"some_binary\">>"
+            }
+          },
+          "amoc_status" : "up",
+          "env" : {
+            "AMOC_INTERARRIVAL" : "50"
+          }
         },
         "properties" : {
-          "node_status" : {
+          "amoc_status" : {
             "enum" : [ "up", "down" ],
+            "type" : "string"
+          },
+          "env" : {
+            "additionalProperties" : {
+              "type" : "string"
+            },
+            "description" : "environment variables",
+            "example" : {
+              "AMOC_INTERARRIVAL" : "50"
+            },
+            "type" : "object"
+          },
+          "controller" : {
+            "$ref" : "#/components/schemas/ControllerStatus"
+          }
+        },
+        "required" : [ "amoc_status", "env" ],
+        "type" : "object"
+      },
+      "ControllerStatus" : {
+        "description" : "controller is \"disabled\" on the master node.\n\n\"scenario\" and \"settings\" fields are included if \"status\" is \"running\", \"terminating\" or \"finished\"\n\n\"number_of_users\" field is relevant only when controller is in \"running\" state.\n\n\"error\" field is relevant only when controller is in \"error\" state.\n",
+        "example" : {
+          "status" : "running",
+          "scenario" : "some_scenario",
+          "number_of_users" : 10,
+          "settings" : {
+            "atom_parameter" : "atom1",
+            "list_parameter" : "[atom1, atom2]",
+            "tuple_parameter" : "{atom1, atom2}",
+            "string_parameter" : "\"some_string\"",
+            "binary_parameter" : "<<\"some_binary\">>"
+          }
+        },
+        "properties" : {
+          "status" : {
+            "enum" : [ "idle", "running", "terminating", "finished", "error", "disabled" ],
+            "type" : "string"
+          },
+          "scenario" : {
+            "type" : "string"
+          },
+          "number_of_users" : {
+            "type" : "integer"
+          },
+          "settings" : {
+            "additionalProperties" : {
+              "type" : "string"
+            },
+            "description" : "Scenario parameters",
+            "example" : {
+              "atom_parameter" : "atom1",
+              "list_parameter" : "[atom1, atom2]",
+              "tuple_parameter" : "{atom1, atom2}",
+              "string_parameter" : "\"some_string\"",
+              "binary_parameter" : "<<\"some_binary\">>"
+            },
+            "type" : "object"
+          },
+          "error" : {
             "type" : "string"
           }
         },
-        "required" : [ "node_status" ],
+        "required" : [ "status" ],
         "type" : "object"
       },
       "UploadBody" : {

--- a/priv/openapi.json
+++ b/priv/openapi.json
@@ -136,7 +136,7 @@
           "name" : "node",
           "required" : true,
           "schema" : {
-            "type" : "string"
+            "$ref" : "#/components/schemas/Node"
           },
           "style" : "simple"
         } ],

--- a/priv/openapi.json
+++ b/priv/openapi.json
@@ -46,7 +46,7 @@
     },
     "/scenarios/info/{id}" : {
       "get" : {
-        "description" : "Get scenario status",
+        "description" : "Get scenario description",
         "parameters" : [ {
           "description" : "Scenario name",
           "explode" : false,
@@ -78,7 +78,7 @@
     },
     "/scenarios/defaults/{id}" : {
       "get" : {
-        "description" : "Get scenario status",
+        "description" : "Get scenario default settings",
         "parameters" : [ {
           "description" : "Scenario name",
           "explode" : false,
@@ -128,9 +128,9 @@
     },
     "/status/{node}" : {
       "get" : {
-        "description" : "Get AMOC app status",
+        "description" : "Get AMOC app status on a remote node",
         "parameters" : [ {
-          "description" : "Scenario name",
+          "description" : "Node name",
           "explode" : false,
           "in" : "path",
           "name" : "node",

--- a/src/amoc_rest_api.erl
+++ b/src/amoc_rest_api.erl
@@ -40,16 +40,16 @@ request_params('ExecutionUpdateSettingsPatch') ->
     ];
 
 
-request_params('ScenariosGet') ->
-    [
-    ];
-
-request_params('ScenariosIdGet') ->
+request_params('ScenariosDefaultsIdGet') ->
     [
         'id'
     ];
 
-request_params('ScenariosIdInfoGet') ->
+request_params('ScenariosGet') ->
+    [
+    ];
+
+request_params('ScenariosInfoIdGet') ->
     [
         'id'
     ];
@@ -65,6 +65,11 @@ request_params('NodesGet') ->
 
 request_params('StatusGet') ->
     [
+    ];
+
+request_params('StatusNodeGet') ->
+    [
+        'node'
     ];
 
 request_params(_) ->
@@ -134,7 +139,7 @@ request_param_info('ExecutionUpdateSettingsPatch', 'ExecutionUpdateSettings') ->
     };
 
 
-request_param_info('ScenariosIdGet', 'id') ->
+request_param_info('ScenariosDefaultsIdGet', 'id') ->
     #{
         source =>  binding ,
         rules => [
@@ -143,7 +148,7 @@ request_param_info('ScenariosIdGet', 'id') ->
         ]
     };
 
-request_param_info('ScenariosIdInfoGet', 'id') ->
+request_param_info('ScenariosInfoIdGet', 'id') ->
     #{
         source =>  binding ,
         rules => [
@@ -152,6 +157,15 @@ request_param_info('ScenariosIdInfoGet', 'id') ->
         ]
     };
 
+
+request_param_info('StatusNodeGet', 'node') ->
+    #{
+        source =>  binding ,
+        rules => [
+            {type, 'binary'},
+            required
+        ]
+    };
 
 request_param_info(OperationID, Name) ->
     error({unknown_param, OperationID, Name}).
@@ -236,17 +250,17 @@ validate_response('ExecutionUpdateSettingsPatch', 500, Body, ValidatorState) ->
     validate_response_body('Error', 'Error', Body, ValidatorState);
 
 
+validate_response('ScenariosDefaultsIdGet', 200, Body, ValidatorState) ->
+    validate_response_body('ScenarioDefaults', 'ScenarioDefaults', Body, ValidatorState);
+validate_response('ScenariosDefaultsIdGet', 404, Body, ValidatorState) ->
+    validate_response_body('', '', Body, ValidatorState);
+
 validate_response('ScenariosGet', 200, Body, ValidatorState) ->
     validate_response_body('ScenarioList', 'ScenarioList', Body, ValidatorState);
 
-validate_response('ScenariosIdGet', 200, Body, ValidatorState) ->
-    validate_response_body('ScenarioStatus', 'ScenarioStatus', Body, ValidatorState);
-validate_response('ScenariosIdGet', 404, Body, ValidatorState) ->
-    validate_response_body('', '', Body, ValidatorState);
-
-validate_response('ScenariosIdInfoGet', 200, Body, ValidatorState) ->
+validate_response('ScenariosInfoIdGet', 200, Body, ValidatorState) ->
     validate_response_body('ScenarioInfo', 'ScenarioInfo', Body, ValidatorState);
-validate_response('ScenariosIdInfoGet', 404, Body, ValidatorState) ->
+validate_response('ScenariosInfoIdGet', 404, Body, ValidatorState) ->
     validate_response_body('', '', Body, ValidatorState);
 
 validate_response('ScenariosUploadPut', 200, Body, ValidatorState) ->
@@ -260,6 +274,11 @@ validate_response('NodesGet', 200, Body, ValidatorState) ->
 
 validate_response('StatusGet', 200, Body, ValidatorState) ->
     validate_response_body('AmocStatus', 'AmocStatus', Body, ValidatorState);
+
+validate_response('StatusNodeGet', 200, Body, ValidatorState) ->
+    validate_response_body('AmocStatus', 'AmocStatus', Body, ValidatorState);
+validate_response('StatusNodeGet', 404, Body, ValidatorState) ->
+    validate_response_body('', '', Body, ValidatorState);
 
 
 validate_response(_OperationID, _Code, _Body, _ValidatorState) ->

--- a/src/amoc_rest_api.erl
+++ b/src/amoc_rest_api.erl
@@ -163,6 +163,7 @@ request_param_info('StatusNodeGet', 'node') ->
         source =>  binding ,
         rules => [
             {type, 'binary'},
+            {pattern, "^[^@]+@[^@]+$" },
             required
         ]
     };

--- a/src/amoc_rest_router.erl
+++ b/src/amoc_rest_router.erl
@@ -80,18 +80,18 @@ get_operations() ->
             method => <<"PATCH">>,
             handler => 'amoc_rest_execution_handler'
         },
+        'ScenariosDefaultsIdGet' => #{
+            path => "/scenarios/defaults/:id",
+            method => <<"GET">>,
+            handler => 'amoc_rest_scenarios_handler'
+        },
         'ScenariosGet' => #{
             path => "/scenarios",
             method => <<"GET">>,
             handler => 'amoc_rest_scenarios_handler'
         },
-        'ScenariosIdGet' => #{
-            path => "/scenarios/:id",
-            method => <<"GET">>,
-            handler => 'amoc_rest_scenarios_handler'
-        },
-        'ScenariosIdInfoGet' => #{
-            path => "/scenarios/:id/info",
+        'ScenariosInfoIdGet' => #{
+            path => "/scenarios/info/:id",
             method => <<"GET">>,
             handler => 'amoc_rest_scenarios_handler'
         },
@@ -107,6 +107,11 @@ get_operations() ->
         },
         'StatusGet' => #{
             path => "/status",
+            method => <<"GET">>,
+            handler => 'amoc_rest_status_handler'
+        },
+        'StatusNodeGet' => #{
+            path => "/status/:node",
             method => <<"GET">>,
             handler => 'amoc_rest_status_handler'
         }

--- a/src/amoc_rest_scenarios_handler.erl
+++ b/src/amoc_rest_scenarios_handler.erl
@@ -49,6 +49,14 @@ init(Req, {Operations, LogicHandler, ValidatorState}) ->
 allowed_methods(
     Req,
     State = #state{
+        operation_id = 'ScenariosDefaultsIdGet'
+    }
+) ->
+    {[<<"GET">>], Req, State};
+
+allowed_methods(
+    Req,
+    State = #state{
         operation_id = 'ScenariosGet'
     }
 ) ->
@@ -57,15 +65,7 @@ allowed_methods(
 allowed_methods(
     Req,
     State = #state{
-        operation_id = 'ScenariosIdGet'
-    }
-) ->
-    {[<<"GET">>], Req, State};
-
-allowed_methods(
-    Req,
-    State = #state{
-        operation_id = 'ScenariosIdInfoGet'
+        operation_id = 'ScenariosInfoIdGet'
     }
 ) ->
     {[<<"GET">>], Req, State};
@@ -109,6 +109,16 @@ content_types_accepted(Req, State) ->
 valid_content_headers(
     Req0,
     State = #state{
+        operation_id = 'ScenariosDefaultsIdGet'
+    }
+) ->
+    Headers = [],
+    {Result, Req} = validate_headers(Headers, Req0),
+    {Result, Req, State};
+
+valid_content_headers(
+    Req0,
+    State = #state{
         operation_id = 'ScenariosGet'
     }
 ) ->
@@ -119,17 +129,7 @@ valid_content_headers(
 valid_content_headers(
     Req0,
     State = #state{
-        operation_id = 'ScenariosIdGet'
-    }
-) ->
-    Headers = [],
-    {Result, Req} = validate_headers(Headers, Req0),
-    {Result, Req, State};
-
-valid_content_headers(
-    Req0,
-    State = #state{
-        operation_id = 'ScenariosIdInfoGet'
+        operation_id = 'ScenariosInfoIdGet'
     }
 ) ->
     Headers = [],

--- a/src/amoc_rest_status_handler.erl
+++ b/src/amoc_rest_status_handler.erl
@@ -62,6 +62,14 @@ allowed_methods(
 ) ->
     {[<<"GET">>], Req, State};
 
+allowed_methods(
+    Req,
+    State = #state{
+        operation_id = 'StatusNodeGet'
+    }
+) ->
+    {[<<"GET">>], Req, State};
+
 allowed_methods(Req, State) ->
     {[], Req, State}.
 
@@ -103,6 +111,16 @@ valid_content_headers(
     Req0,
     State = #state{
         operation_id = 'StatusGet'
+    }
+) ->
+    Headers = [],
+    {Result, Req} = validate_headers(Headers, Req0),
+    {Result, Req, State};
+
+valid_content_headers(
+    Req0,
+    State = #state{
+        operation_id = 'StatusNodeGet'
     }
 ) ->
     Headers = [],


### PR DESCRIPTION
https://esl.github.io/amoc_rest/?v=status-api

I played a bit with `oneOf` and [Discriminator Object](https://swagger.io/specification/#discriminator-object) for `amoc_controller` status (as a recommended by OpenAPI spec way of polymorphism support). But as usual, it doesn't work out of the box. So I've decided that it's not that critical and just made status fields optional to unblock the implementation.